### PR TITLE
fix: github url to edit document

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,7 +5,11 @@ book:
   title: "Building reproducible analytical pipelines with R"
   author: "Bruno Rodrigues"
   date: "2023-04-23"
-  site-url: "https://github.com/b-rodrigues/rap4all"
+  search: true
+  repo-url: "https://github.com/b-rodrigues/rap4all"
+  repo-actions: [edit]
+  sharing: [twitter, facebook]
+  downloads: [pdf, epub]
   chapters:
     - index.qmd
     - preface.qmd


### PR DESCRIPTION
Hi, I propose to add a few options in the book to ease collaboration.

- Use 'repo-url' to get a 'Edit this page' link
- Add links to download PDF and epub
- Allow sharing on twitter, facebook

![image](https://github.com/b-rodrigues/rap4all/assets/21193866/1e5a8f95-1563-4387-9e0d-07c708cf258e)  
![image](https://github.com/b-rodrigues/rap4all/assets/21193866/cb825398-6786-4622-a6e5-6595d0d57e4e)
