### PR TITLE
Changed potential typo

### DIFF
--- a/fprog.qmd
+++ b/fprog.qmd
@@ -484,10 +484,10 @@ sqrt(-5)
 This only raises a warning and returns `NaN` (Not a Number). This can be quite
 dangerous, especially when working non-interactively, which is what we will be
 doing a lot later on. It is much better if a pipeline fails early due to an
-error, than dragging a `NaN` value. This also happens with `sqrt()`:
+error, than dragging a `NaN` value. This also happens with `log10()`:
 
 ```{r}
-sqrt(-10)
+log10(-10)
 ```
 
 So it could be useful to redefine these functions to raise an error instead, for
@@ -705,7 +705,6 @@ fact_iter <- function(n){
   result = 1
   for(i in 1:n){
     result = result * i
-    i = i + 1
   }
   result
 }


### PR DESCRIPTION
Hi Bruno,

I have found a small potential typo in Chapter 6 Functional Programming, 6.2 Writing good functions, 6.2.1 Functions are first-class objects. You give examples of both sqrt(-5) and sqrt(-10) lead to warnings NaNs produced. I wondered if the second should have been log10(-10) instead?

Also, in 6.2.4 Recursive functions. You include i = i +1 in the iterative function and I am not sure the reason? I believe the function works fine without?

This is my first pull request so apologies for being so pedantic but I wanted to try it out also!

Thanks,
Jake