### PR TITLE
Renamed add_sweet_feature to add_nice_feature for consistency

### DIFF
--- a/github.qmd
+++ b/github.qmd
@@ -723,7 +723,7 @@ and this is the owner:
 ```bash
 owner@localhost ➤ git add .
 owner@localhost ➤ git commit -m "cleanup"
-owner@localhost ➤ git push origin add_sweet_feature
+owner@localhost ➤ git push origin add_nice_feature
 ```
 :::
 
@@ -731,7 +731,7 @@ owner@localhost ➤ git push origin add_sweet_feature
 ```bash
 owner@localhost $ git add .
 owner@localhost $ git commit -m "cleanup"
-owner@localhost $ git push origin add_sweet_feature
+owner@localhost $ git push origin add_nice_feature
 ```
 :::
 
@@ -745,11 +745,11 @@ Writing objects: 100% (3/3), 449 bytes | 449.00 KiB/s, done.
 Total 3 (delta 1), reused 0 (delta 0)
 remote: Resolving deltas: 100% (1/1), completed with 1 local object.
 remote:
-remote: Create a pull request for 'add_sweet_feature' on GitHub by visiting:
-remote:      https://github.com/rap4all/housing/pull/new/add_sweet_feature
+remote: Create a pull request for 'add_nice_feature' on GitHub by visiting:
+remote:      https://github.com/rap4all/housing/pull/new/add_nice_feature
 remote:
 To github.com:rap4all/housing.git
- * [new branch]      add_sweet_feature -> add_sweet_feature
+ * [new branch]      add_nice_feature -> add_nice_feature
 ```
 :::
 
@@ -763,11 +763,11 @@ Writing objects: 100% (3/3), 449 bytes | 449.00 KiB/s, done.
 Total 3 (delta 1), reused 0 (delta 0)
 remote: Resolving deltas: 100% (1/1), completed with 1 local object.
 remote:
-remote: Create a pull request for 'add_sweet_feature' on GitHub by visiting:
-remote:      https://github.com/rap4all/housing/pull/ new/add_sweet_feature
+remote: Create a pull request for 'add_nice_feature' on GitHub by visiting:
+remote:      https://github.com/rap4all/housing/pull/ new/add_nice_feature
 remote:
 To github.com:rap4all/housing.git
- * [new branch]      add_sweet_feature -> add_sweet_feature
+ * [new branch]      add_nice_feature -> add_nice_feature
 ```
 :::
 
@@ -900,7 +900,7 @@ owner@localhost $ git status
 :::
 
 ```bash
-On branch add_sweet_feature
+On branch add_nice_feature
 nothing to commit, working tree clean
 ```
 


### PR DESCRIPTION
The branch "add_nice_feature" is referred to as "add_sweet_feature" in the code example. I renamed the references to "add_sweet_feature" to "add_nice_feature" for consistency.