### PR TITLE
rmd_intro to rmd_test

### DIFF
--- a/lit_prog.qmd
+++ b/lit_prog.qmd
@@ -459,7 +459,7 @@ My favourite programming language for statistics is ~~SAS~~ R.
 
 ````
 
-save this document into a file called `rmd_intro.rmd` using your favourite
+save this document into a file called `rmd_test.rmd` using your favourite
 text editor. Then render it into an Html file by running the following command
 in the R console:
 


### PR DESCRIPTION
Hi Bruno,

I found a typo in the _Literate Programming_ chapter. The `.Rmd` file is initially referred to as `rmd_intro.rmd` but referenced 
as `rmd_test.rmd` afterwards. I changed the intial reference from `rmd_intro.rmd`-> `rmd_test.rmd` for consistency.

Thanks!
Karla