### PR TITLE
Correct links to blog posts

### DIFF
--- a/preface.qmd
+++ b/preface.qmd
@@ -34,9 +34,9 @@ This is reflected in my blogging. As I’m writing these lines (beginning of
 2023), I have been blogging for about ten years. Most of my blog posts are me
 trying to lay out a problem I had at work and how I solved it. Sometimes I do
 some things for pleasure or curiosity, like the [two posts on the video game
-nethack](https://www.brodrigues.co/blog/2018-11-03-nethack_analysis/), or the
+nethack](https://brodrigues.co/posts/2018-11-03-nethack_analysis.html), or the
 ones [on 19th century
-newspapers](https://www.brodrigues.co/blog/2019-01-04-newspapers/) where I
+newspapers](https://brodrigues.co/posts/2019-01-04-newspapers.html) where I
 learned a lot about NLP. Because I was lucky enough to work with different
 people from many backgrounds, I always had to solve a very wide range of
 problems.


### PR DESCRIPTION
Updated blog post links becausethe old ones go to pages with 'permanently moved' notices (only noticed this after submitting #73!).